### PR TITLE
fix(oauth): request Mail.Send scope for Outlook connections

### DIFF
--- a/src/utility/getOutlookUrl.ts
+++ b/src/utility/getOutlookUrl.ts
@@ -47,6 +47,7 @@ export async function buildOutlookOAuthRedirectUrl(orgId: string | undefined): P
     "User.Read",
     "Mail.Read",
     "Mail.ReadWrite",
+    "Mail.Send",
   ].join(" ")
 
   const qs = new URLSearchParams({


### PR DESCRIPTION
## Problem

The Outlook authorize URL didn't request the `Mail.Send` Graph scope, so tokens stored for connected accounts couldn't be used by the agent's outreach send step.

## Changes

- **`src/utility/getOutlookUrl.ts`** — add `Mail.Send` to the delegated scopes in the Outlook OAuth authorize URL.

## Notes for reviewers

- Companion backend PR fixes the token-retention issues and documents the required Azure setup (including granting `Mail.Send` API permission): sabinss/ai-assistant-backend#60.
- Already-connected accounts must **reconnect** to pick up the new scope — existing tokens won't gain it.

## Testing

- Connect an Outlook account and confirm the consent screen lists "Send mail as you", and the resulting token's `scope` includes `Mail.Send`.