### PR TITLE
fix: drop unapproved gmail.modify scope from OAuth request

### DIFF
--- a/src/utility/getGoogleUrl.ts
+++ b/src/utility/getGoogleUrl.ts
@@ -15,7 +15,6 @@ function getGoogleOAuthURL(orgId: any) {
       "https://www.googleapis.com/auth/gmail.send",
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/gmail.compose",
-      "https://www.googleapis.com/auth/gmail.modify",
     ].join(" "),
   }
 


### PR DESCRIPTION
## Problem

Users hit **"Google hasn't verified this app"** on sign-in, despite the Verification Center reporting both branding and data access as verified.

## Cause

`src/utility/getGoogleUrl.ts` requested `gmail.modify`, which was never registered or approved for this project.

Google's approval email for project `cowrkr-prod` (`647518190490`), dated 2025-09-13, lists exactly three Gmail scopes:

| Scope | Tier | Approved |
|---|---|---|
| `gmail.send` | sensitive | ✅ |
| `gmail.readonly` | restricted | ✅ |
| `gmail.compose` | restricted | ✅ |
| `gmail.modify` | restricted | ❌ never registered |

A single unapproved restricted scope pushes the **entire** consent request to the unverified interstitial — the other three being verified doesn't help.

## Fix

Remove `gmail.modify` from the requested scope list.

Nothing reads it. The backend (`gmail_outreach.py`, `email_lambda/lib/gmail.py`) uses only send/readonly/compose, and `compose` already covers draft creation and sending. `modify` would only add label, read-state, and delete operations, none of which are implemented.

## Why this needs no re-verification

This changes only what the client *requests*, not what the project has *registered*. Registered scopes are untouched, so no new verification submission is triggered.

## Deploy note

⚠️ `NEXT_PUBLIC_*` values are inlined at build time — **a rebuild and redeploy is required** for this to take effect.

Existing users keep `gmail.modify` on their current refresh tokens until they re-consent. Since no code path uses it, there is no behavioural change.

## Out of scope

CASA Tier 2 recertification is due by **2026-09-13** and is tracked separately. Deliberately not adding `gmail.modify` to the registered scopes right now — a new scope request during recertification would stall both.